### PR TITLE
chore: Bump to version 0.6.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["gamedev", "bevy"]
 license = "MIT OR Apache-2.0"
 name = "bevy_crossbeam_event"
 repository = "https://github.com/johanhelsing/bevy_crossbeam_event"
-version = "0.5.0"
+version = "0.6.0"
 
 [dependencies]
 bevy = { version = "0.14", default-features = false }

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ The `main` branch targets the latest bevy release.
 
 |bevy|bevy_crossbeam_event|
 |----|--------------------|
-|0.13| 0.5, main          |
+|0.14| 0.6, main          |
+|0.13| 0.5                |
 |0.12| 0.3                |
 |0.11| 0.2                |
 |0.10| 0.1                |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,9 +9,9 @@ impl<T: Event> CrossbeamEventSender<T> {
         let event = event.into();
         if let Err(err) = self.0.try_send(event) {
             match err {
-                // we have an unbounded channel, so this would only happen if we're out of memory
+                // We have an unbounded channel, so this would only happen if we're out of memory.
                 TrySendError::Full(_) => panic!("unable to send event, channel full"),
-                // This should only happen if callbacks happen as the app is shutting down, so we ignore it
+                // This should only happen if callbacks happen as the app is shutting down, so we ignore it.
                 TrySendError::Disconnected(_) => {}
             }
         };


### PR DESCRIPTION
Just hoping for a new version targeting bevy 0.14 to be published. This solves issue #6, which I submitted.