### PR TITLE
Upgrade to bevy 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ keywords = ["gamedev", "bevy"]
 license = "MIT OR Apache-2.0"
 name = "bevy_crossbeam_event"
 repository = "https://github.com/johanhelsing/bevy_crossbeam_event"
-version = "0.9.0"
+version = "0.10.0"
 
 [dependencies]
-bevy = { version = "0.17", default-features = false }
+bevy = { version = "0.18", default-features = false }
 crossbeam-channel = "0.5"

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ The `main` branch targets the latest bevy release.
 
 |bevy|bevy_crossbeam_event|
 |----|--------------------|
-|0.17| 0.9, main          |
+|0.18| 0.10, main         |
+|0.17| 0.9                |
 |0.16| 0.8                |
 |0.15| 0.7                |
 |0.14| 0.6                |


### PR DESCRIPTION
Doing a pass on all my dependencies as I upgrade my project to 0.18, this was very straightforward and figured it might be helpful to have this. 🙂